### PR TITLE
Add extra_sources option and allow to add hashes as a settings source

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -33,14 +33,15 @@ module Config
     @@_ran_once = true
   end
 
-  # Create a populated Options instance from a settings file. If a second file is given, then the sections of that
-  # file will overwrite existing sections of the first file.
-  def self.load_files(*files)
+  # Create a populated Options instance from a settings source. If a second source is given, then the sections of that
+  # source will overwrite existing sections of the first source.
+  # Source can be either file or hash.
+  def self.load_sources(*sources)
     config = Options.new
 
     # add settings sources
-    [files].flatten.compact.uniq.each do |file|
-      config.add_source!(file.to_s)
+    [sources].flatten.compact.uniq.each do |source|
+      config.add_source!(source)
     end
 
     config.load!
@@ -51,7 +52,7 @@ module Config
   # Loads and sets the settings constant!
   def self.load_and_set_settings(*files)
     Kernel.send(:remove_const, Config.const_name) if Kernel.const_defined?(Config.const_name)
-    Kernel.const_set(Config.const_name, Config.load_files(files))
+    Kernel.const_set(Config.const_name, Config.load_sources(files))
   end
 
   def self.setting_files(config_root, env)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -15,13 +15,15 @@ module Config
   # Ensures the setup only gets run once
   @@_ran_once = false
 
-  mattr_accessor :const_name, :use_env, :env_prefix, :env_separator, :env_converter, :env_parse_values
+  mattr_accessor :const_name, :use_env, :env_prefix, :env_separator,
+                 :env_converter, :env_parse_values, :extra_sources
   @@const_name = 'Settings'
   @@use_env    = false
   @@env_prefix = @@const_name
   @@env_separator = '.'
   @@env_converter = :downcase
   @@env_parse_values = true
+  @@extra_sources = []
 
   # deep_merge options
   mattr_accessor :knockout_prefix, :overwrite_arrays
@@ -40,7 +42,7 @@ module Config
     config = Options.new
 
     # add settings sources
-    [sources].flatten.compact.uniq.each do |source|
+    [sources + extra_sources].flatten.compact.uniq.each do |source|
       config.add_source!(source)
     end
 
@@ -50,9 +52,13 @@ module Config
   end
 
   # Loads and sets the settings constant!
-  def self.load_and_set_settings(*files)
+  def self.load_and_set_settings(*sources)
     Kernel.send(:remove_const, Config.const_name) if Kernel.const_defined?(Config.const_name)
-    Kernel.const_set(Config.const_name, Config.load_sources(files))
+    Kernel.const_set(Config.const_name, Config.load_sources(sources))
+  end
+
+  def self.add_extra_source(source)
+    extra_sources << source
   end
 
   def self.setting_files(config_root, env)

--- a/lib/config/sources/hash_source.rb
+++ b/lib/config/sources/hash_source.rb
@@ -9,7 +9,7 @@ module Config
 
       # returns hash that was passed in to initialize
       def load
-        hash.is_a?(Hash) ? hash : {}
+        hash.is_a?(Hash) ? hash.stringify_keys : {}
       end
     end
   end

--- a/lib/config/sources/hash_source.rb
+++ b/lib/config/sources/hash_source.rb
@@ -9,7 +9,7 @@ module Config
 
       # returns hash that was passed in to initialize
       def load
-        hash.is_a?(Hash) ? hash.stringify_keys : {}
+        hash.is_a?(Hash) ? hash.deep_stringify_keys : {}
       end
     end
   end

--- a/lib/generators/config/templates/config.rb
+++ b/lib/generators/config/templates/config.rb
@@ -42,4 +42,11 @@ Config.setup do |config|
   #   required(:email).filled(format?: EMAIL_REGEX)
   # end
 
+  # Define extra sources of config values. Each source can be either file path or hash.
+  # Extra sources will be merged with base settings files.
+  #
+  # config.extra_sources = [
+  #   File.join('app_root', 'config', 'extra_settings.yml').to_s,
+  #   { some_api_key: 'secret_key' }
+  # ]
 end

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -4,7 +4,7 @@ describe Config do
 
   context 'when overriding settings via ENV variables is enabled' do
     let(:config) do
-      Config.load_files "#{fixture_path}/settings.yml", "#{fixture_path}/multilevel.yml"
+      Config.load_sources "#{fixture_path}/settings.yml", "#{fixture_path}/multilevel.yml"
     end
 
     before :all do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -379,5 +379,44 @@ describe Config do
       end
 
     end
+
+    context 'with extra sources' do
+      before do
+        Config.reset
+      end
+
+      context 'in configuration phase' do
+        it 'should have empty array as default extra_sources value' do
+          expect(Config.extra_sources).to eq([])
+        end
+
+        it 'should be able to assign a different extra_sources values' do
+          Config.extra_sources = ['extra_config.yml', { some_key: 'some_value' }]
+
+          expect(Config.extra_sources).to eq(['extra_config.yml', { some_key: 'some_value' }])
+        end
+      end
+
+      context 'merging' do
+        let(:hash) do
+          { app_name: 'App',
+            external_service: { api_key: 'super_secret_key' }}
+        end
+        let(:config) do
+          Config.load_sources(["#{fixture_path}/extra_sources/config1.yml",
+                               "#{fixture_path}/extra_sources/config2.yml",
+                               hash])
+        end
+        let(:expected_config) do
+          { app_name: 'App',
+            external_service: { api_key: 'super_secret_key', items_per_page: 20 },
+            avatar: { width: 128, height: 128 }}
+        end
+
+        it 'should merge settings from multiple sources' do
+          expect(config.to_hash).to eq(expected_config)
+        end
+      end
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -398,14 +398,18 @@ describe Config do
       end
 
       context 'merging' do
-        let(:hash) do
+        let(:hash1) do
+          { avatar: { width: 64, height: 64 } }
+        end
+        let(:hash2) do
           { app_name: 'App',
             external_service: { api_key: 'super_secret_key' }}
         end
         let(:config) do
-          Config.load_sources(["#{fixture_path}/extra_sources/config1.yml",
+          Config.load_sources([hash1,
+                               "#{fixture_path}/extra_sources/config1.yml",
                                "#{fixture_path}/extra_sources/config2.yml",
-                               hash])
+                               hash2])
         end
         let(:expected_config) do
           { app_name: 'App',

--- a/spec/fixtures/extra_sources/config1.yml
+++ b/spec/fixtures/extra_sources/config1.yml
@@ -1,0 +1,7 @@
+app_name: App1
+external_service:
+  api_key: secret_key
+  items_per_page: 10
+avatar:
+  width: 128
+  height: 128

--- a/spec/fixtures/extra_sources/config2.yml
+++ b/spec/fixtures/extra_sources/config2.yml
@@ -1,0 +1,3 @@
+app_name: App2
+external_service:
+  items_per_page: 20

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -4,7 +4,7 @@ describe Config::Options do
 
   context 'when Settings file is using keywords reserved for OpenStruct' do
     let(:config) do
-      Config.load_files("#{fixture_path}/reserved_keywords.yml")
+      Config.load_sources("#{fixture_path}/reserved_keywords.yml")
     end
 
     it 'should allow to access them via object member notation' do
@@ -26,7 +26,7 @@ describe Config::Options do
 
   context 'adding sources' do
     let(:config) do
-      Config.load_files("#{fixture_path}/settings.yml")
+      Config.load_sources("#{fixture_path}/settings.yml")
     end
 
     before do
@@ -68,7 +68,7 @@ describe Config::Options do
 
   context 'prepending sources' do
     let(:config) do
-      Config.load_files("#{fixture_path}/settings.yml")
+      Config.load_sources("#{fixture_path}/settings.yml")
     end
 
     before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
       def self.reset
         self.const_name       = 'Settings'
         self.use_env          = false
+        self.extra_sources    = []
         self.knockout_prefix  = nil
         self.overwrite_arrays = true
         self.schema           = nil if RUBY_VERSION >= '2.1'

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -18,7 +18,7 @@ if RUBY_VERSION >= '2.1'
           end
         end
 
-        expect { Config.load_files("#{fixture_path}/validation/config.yml") }.
+        expect { Config.load_sources("#{fixture_path}/validation/config.yml") }.
           to raise_error(Config::Validation::Error, /youtube.nonexist_field: is missing/)
       end
 
@@ -31,7 +31,7 @@ if RUBY_VERSION >= '2.1'
           end
         end
 
-        expect { Config.load_files("#{fixture_path}/validation/config.yml") }.
+        expect { Config.load_sources("#{fixture_path}/validation/config.yml") }.
           to_not raise_error
       end
     end


### PR DESCRIPTION
Hey! 
I've added new feature, which allows to define extra config sources before config load.
I think this feature will be useful, because starting from this version **config validation** feature will be available. Unfortunately, validation doesn't work well, when you want to add new config files - it's impossible to validate values that appear in the files added at the runtime (using `Settings.add_source!`).

This may be also a sort of remedy for railsconfig/config#142.