### PR TITLE
Ignore .local files in cucumber environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-...
+### Changes
+
+* Ignore .local files in cucumber environment ([#269](https://github.com/railsconfig/config/pull/269))
 
 ## 2.2.1
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -64,7 +64,7 @@ module Config
 
   def self.local_setting_files(config_root, env)
     [
-      (File.join(config_root, 'settings.local.yml').to_s if env != 'test'),
+      (File.join(config_root, 'settings.local.yml').to_s if env != 'test' && env != 'cucumber'),
       File.join(config_root, 'settings', "#{env}.local.yml").to_s,
       File.join(config_root, 'environments', "#{env}.local.yml").to_s
     ].compact

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -25,6 +25,17 @@ describe Config do
                          ])
   end
 
+  it "should ignore local config in cucumber environment" do
+    config = Config.setting_files("root/config", "cucumber")
+    expect(config).to eq([
+                           'root/config/settings.yml',
+                           'root/config/settings/cucumber.yml',
+                           'root/config/environments/cucumber.yml',
+                           'root/config/settings/cucumber.local.yml',
+                           'root/config/environments/cucumber.local.yml'
+                         ])
+  end
+
   it "should load a basic config file" do
     config = Config.load_files("#{fixture_path}/settings.yml")
     expect(config.size).to eq(1)


### PR DESCRIPTION
Since https://github.com/rubyconfig/config/pull/233 we're ignoring .local files in `test` environment, do the same in `cucumber` for consistency.