### PR TITLE
Add hanami support

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -80,3 +80,7 @@ require('config/integrations/rails/railtie') if defined?(::Rails)
 
 # Sinatra integration
 require('config/integrations/sinatra') if defined?(::Sinatra)
+
+# Hanami integration and generator
+require('generators/config/hanami_install_generator') if defined?(::Hanami)
+require('config/integrations/hanami') if defined?(::Hanami)

--- a/lib/config/integrations/hanami.rb
+++ b/lib/config/integrations/hanami.rb
@@ -1,0 +1,9 @@
+require "config/rack/reloader"
+
+::Hanami.plugin do
+  env = ::Hanami.env
+  root = ::Hanami.root
+  Config.load_and_set_settings(Config.setting_files(File.join(root, 'config'), env))
+
+  middleware.use(::Config::Rack::Reloader) if env == "development"
+end

--- a/lib/generators/config/hanami_install_generator.rb
+++ b/lib/generators/config/hanami_install_generator.rb
@@ -1,0 +1,18 @@
+module Config
+  module Generators
+    class HanamiInstallGenerator < ::Hanami::CLI::Commands::Command
+      requires "environment"
+
+      desc "Generates a custom Hanami Config initializer file."
+
+      def call(*)
+        files.cp File.expand_path("../templates/config.rb", __FILE__), ::Hanami.root.join("config/initializers/config.rb")
+        files.cp File.expand_path("../templates/settings.yml", __FILE__), ::Hanami.root.join("config/settings.yml")
+        files.cp File.expand_path("../templates/settings.local.yml", __FILE__), ::Hanami.root.join("config/settings.local.yml")
+        FileUtils.cp_r File.expand_path("../templates/settings", __FILE__), ::Hanami.root.join("config/settings")
+      end
+    end
+  end
+end
+
+::Hanami::CLI.register "generate config", Config::Generators::HanamiInstallGenerator


### PR DESCRIPTION
I add hanami support. 🌸
```
# in Gemfile
group :plugins do
  gem "config"
end
```

```
bundle exec hanami config
``` 
This code works well in `1.7.0` of rubyconfig/config.
But this is not usable in `2.2.1`. Because `dry-validation` version is difference in gemspec

```
# in rubyconfig/config
s.add_dependency 'dry-validation', '~> 1.0', '>= 1.0.0'	

# in hanami/validations	
spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
```

I don't know what to do for this problem.
I hope this PR helps you!. 😄 