### PR TITLE
Fix local test run by reinstating the check against the appraisal env variable

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.25", platform: :jruby
-gem "rails", "4.2.11.1"
+gem "rails", "4.2.11.3"
 gem "rspec-rails", "~> 3.7"
 gem "sprockets", "~> 3.7"
 gem "sqlite3", "< 1.4.0", platform: :ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 ##
 # Detect Rails/Sinatra dummy application based on gemfile name substituted by Appraisal
 #
-if ENV['GITHUB_ACTIONS']
+if ENV['APPRAISAL_INITIALIZED'] || ENV['GITHUB_ACTIONS']
   app_name = Pathname.new(ENV['BUNDLE_GEMFILE']).basename.sub('.gemfile', '')
 else
   /.*?(?<app_name>rails.*?)\.gemfile/ =~ Dir["gemfiles/rails*.gemfile"].sort.last


### PR DESCRIPTION
rspec tests were not passing locally without this when using:
```
bundle exec appraisal rspec
```

Fixes #283 