### PR TITLE
Add exit! to reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * Add JRuby 9.2 to the test matrix ([#228](https://github.com/railsconfig/config/issues/228))
+* Add exit! to reserved keywords ([#289](https://github.com/railsconfig/config/issues/289))
 
 ## 2.2.1
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -145,7 +145,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max].freeze
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max exit!].freeze
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -4,3 +4,4 @@ count: lemon
 zip: cherry
 max: kumquat
 min: fig
+exit!: taro

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -14,6 +14,7 @@ describe Config::Options do
       expect(config.zip).to eq('cherry')
       expect(config.max).to eq('kumquat')
       expect(config.min).to eq('fig')
+      expect(config.exit!).to eq('taro')
     end
 
     it 'should allow to access them using [] operator' do
@@ -23,6 +24,7 @@ describe Config::Options do
       expect(config['zip']).to eq('cherry')
       expect(config['max']).to eq('kumquat')
       expect(config['min']).to eq('fig')
+      expect(config['exit!']).to eq('taro')
 
       expect(config[:select]).to eq('apple')
       expect(config[:collect]).to eq('banana')
@@ -30,6 +32,7 @@ describe Config::Options do
       expect(config[:zip]).to eq('cherry')
       expect(config[:max]).to eq('kumquat')
       expect(config[:min]).to eq('fig')
+      expect(config[:exit!]).to eq('taro')
     end
   end
 


### PR DESCRIPTION
Calling `Config::Options#[]` with the parameter `'exit!'` will invoke `Kernel#exit!` and immediately terminate the program. Instead, we want to handle this key explicitly, not because it's likely to be used as a key in a legitimate config yaml file, but to prevent a potential DOS vector if accessing options with untrusted input.