### PR TITLE
Prevent unnecessary doubled loading of environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Added alias to_h for to_hash ([#277](https://github.com/railsconfig/config/issues/277))
+* Stop double-loading environment variables unnecessarily ([#291](https://github.com/rubyconfig/config/pull/291))
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * Added alias to_h for to_hash ([#277](https://github.com/railsconfig/config/issues/277))
-* Stop double-loading environment variables unnecessarily ([#291](https://github.com/rubyconfig/config/pull/291))
+* Prevent unnecessary doubled loading of environment variables ([#291](https://github.com/rubyconfig/config/pull/291))
 
 ### Changes
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -42,7 +42,6 @@ module Config
     end
 
     config.load!
-    config.load_env! if use_env
     config
   end
 


### PR DESCRIPTION
Calling `Config.load_files` ends up reading environment variables and setting them in the `Options` object twice.

`Config.load_files` calls `Options#load!` (an alias for `Options#reload!`), which calls `Options#reload_env!`.

Then `Config.load_files` immediately calls `Options#load_env!`, which is just an alias for `Options#reload_env!`.

Since `Options#reload_env!` is idempotent, I can't imagine this being necessary or desirable. This redundancy has present since support for overriding settings with environment variables was introduced in #64. 