### PR TITLE
Add explicit implementation of Config::Options#as_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added alias to_h for to_hash ([#277](https://github.com/railsconfig/config/issues/277))
 * Prevent unnecessary doubled loading of environment variables ([#291](https://github.com/rubyconfig/config/pull/291))
+* Return `Hash` from `Config::Options#as_json` instead of `Array` of pairs when using ActiveSupport Core Extensions ([#292](https://github.com/rubyconfig/config/pull/292))
 
 ### Changes
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -129,6 +129,10 @@ module Config
       to_hash.to_json(*args)
     end
 
+    def as_json(options = nil)
+      to_hash.as_json(options)
+    end
+
     def merge!(hash)
       current = to_hash
       DeepMerge.deep_merge!(

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -224,4 +224,10 @@ describe Config::Options do
 
   end
 
+  context 'when calling #as_json' do
+    it 'should return a Hash of the keys and values' do
+      options = Config::Options.new(foo: :bar)
+      expect(options.as_json).to eq({ 'foo' => 'bar' })
+    end
+  end
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -226,6 +226,15 @@ describe Config::Options do
 
   context 'when calling #as_json' do
     it 'should return a Hash of the keys and values' do
+      unless defined?(::Rails)
+        skip <<~REASON
+          Config::Options#as_json raises a runtime error unless Active Support
+          Core Extensions are loaded. We don't expect users to call this method
+          at all if they're not using AS, so we disable this test except when
+          running the suite against Rails.
+        REASON
+      end
+
       options = Config::Options.new(foo: :bar)
       expect(options.as_json).to eq({ 'foo' => 'bar' })
     end


### PR DESCRIPTION
Fixes #287 

Before, `Config::Options#as_json` was not explicitly defined, but the class included the `Enumerable` module. So, if you were using ActiveSupport Core Extensions, then the definition of `#as_json` for Enumerable was invoked, which would represent the `Config::Options` as a Array of key-value pairs instead of a Hash.

This changes brings `#as_json` in line with the output we get from `to_json`: essentially, calling these methods on an instance of `Config::Options` behaves the same as if they were called instead on the hash returned by `to_hash`.

It's not clear if this is a "bug fix" or a "breaking change" from a semver perspective, but I think it's unlikely that someone was depending on the output from `#as_json` to be the Array-of-pairs representation.