### PR TITLE
Raise explicit error on env var conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Bug fixes
+
 ...
+
+### Changes
+
+* Raise explicit error on environment variable conflicts ([#293](https://github.com/railsconfig/config/issues/293))
 
 ## 2.2.2
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,21 @@ ENV['Settings.section.server'] = 'google.com'
 
 It won't work with arrays, though.
 
+It is considered an error to use environment variables to simutaneously assign a "flat" value and a multi-level value to a key.
+
+```ruby
+# Raises an error when settings are loaded
+ENV['BACKEND_DATABASE'] = 'development'
+ENV['BACKEND_DATABASE_USER'] = 'postgres'
+```
+
+Instead, specify keys of equal depth in the environment variable names:
+
+```ruby
+ENV['BACKEND_DATABASE_NAME'] = 'development'
+ENV['BACKEND_DATABASE_USER'] = 'postgres'
+```
+
 ### Working with Heroku
 
 Heroku uses ENV object to store sensitive settings. You cannot upload such files to Heroku because it's ephemeral filesystem gets recreated from the git sources on each instance refresh. To use config with Heroku just set the `use_env` var to `true` as mentioned above.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ Settings.add_source!("#{Rails.root}/config/settings/local.yml")
 Settings.reload!
 ```
 
-> Note: this is an example usage, it is easier to just use the default local files `settings.local.yml,
-settings/#{Rails.env}.local.yml and environments/#{Rails.env}.local.yml` for your developer specific settings.
+> Note: this is an example usage, it is easier to just use the default local
+> files `settings.local.yml`, `settings/#{Rails.env}.local.yml` and
+> `environments/#{Rails.env}.local.yml` for your developer specific settings.
 
 You also have the option to add a raw hash as a source. One use case might be storing settings in the database or in environment variables that overwrite what is in the YML files.
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -59,6 +59,11 @@ module Config
           h[key] ||= {}
         }
 
+        unless leaf.is_a?(Hash)
+          conflicting_key = (prefix + keys[0...-1]).join(separator)
+          raise "Environment variable #{variable} conflicts with variable #{conflicting_key}"
+        end
+
         leaf[keys.last] = Config.env_parse_values ? __value(value) : value
       end
 

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -213,5 +213,12 @@ describe Config::Options do
       expect(config.new_var).to eq('value')
     end
 
+    context 'and env variable names conflict with existing namespaces' do
+      it 'should allow overriding the namespace' do
+        ENV['Settings.databases'] = 'new databases'
+
+        expect(config.databases).to eq('new databases')
+      end
+    end
   end
 end

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -213,6 +213,17 @@ describe Config::Options do
       expect(config.new_var).to eq('value')
     end
 
+    context 'and env variable names conflict with new namespaces' do
+      it 'should throw a descriptive error message' do
+        ENV['Settings.backend_database'] = 'development'
+        ENV['Settings.backend_database.user'] = 'postgres'
+
+        expected_message = 'Environment variable Settings.backend_database.user '\
+          'conflicts with variable Settings.backend_database'
+        expect { config }.to raise_error(RuntimeError, expected_message)
+      end
+    end
+
     context 'and env variable names conflict with existing namespaces' do
       it 'should allow overriding the namespace' do
         ENV['Settings.databases'] = 'new databases'


### PR DESCRIPTION
Fixes #205

Suppose the user sets the variables `Settings.backend_database` in addition to `Settings.backend_database.user`. Since it is possible to override existing settings with env vars, one possible way to handle this is to process the environment variables in a well-defined order and allow lexicographically greater keys to override lower ones. However, it's probably not what the user intended to happen, so instead we raise a descriptive error when a conflict is detected.

This is likely not a breaking change because a `RuntimeError` is already raised in this case, it's just not very friendly:

    TypeError:
      no implicit conversion of Symbol into Integer

Now we raise a nicer error

    RuntimeError:
        Environment variable Settings.backend_database.user conflicts
        with variable Settings.backend_database