### PR TITLE
Revert "Added alias to_h for to_hash (#277)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-...
+### Bug fixes
+
+* Revert added alias to_h for to_hash ([#277](https://github.com/railsconfig/config/issues/277))
 
 ## 2.2.2
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -118,8 +118,6 @@ module Config
       result
     end
 
-    alias :to_h :to_hash
-
     def each(*args, &block)
       marshal_dump.each(*args, &block)
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -80,15 +80,6 @@ describe Config do
     expect(config[:section][:servers][1]).to be_kind_of(Config::Options)
   end
 
-  it "should convert to a hash without modifying nested settings" do
-    config = Config.load_files("#{fixture_path}/development.yml")
-    config.to_h
-    expect(config).to be_kind_of(Config::Options)
-    expect(config[:section]).to be_kind_of(Config::Options)
-    expect(config[:section][:servers][0]).to be_kind_of(Config::Options)
-    expect(config[:section][:servers][1]).to be_kind_of(Config::Options)
-  end
-
   it "should convert to a json" do
     config = Config.load_files("#{fixture_path}/development.yml").to_json
     expect(JSON.parse(config)["section"]["servers"]).to be_kind_of(Array)


### PR DESCRIPTION
This reverts commit 4b65ca6f

See: https://github.com/rubyconfig/config/issues/217#issuecomment-741953382

Refs #277