### PR TITLE
Refactor environment variable handling into new Sources::EnvSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
 ### BREAKING CHANGES
 
 After upgrade behaviour of `to_h` would change and match behaviour of `to_hash`. Check [#217](https://github.com/rubyconfig/config/issues/217#issuecomment-741953382) for more details.
+`Config::Options#load_env!` and `Config::Options#reload_env!` have been removed. If you need to reload settings after modifying the `ENV` hash, use `Config.reload!` or `Config::Options#reload!` instead.
 
 ### Bug fixes
 
 * Added alias `to_h` for `to_hash` ([#277](https://github.com/railsconfig/config/issues/277))
+
+### Changes
+
+* Add `Config::Sources::EnvSource` for loading settings from flat `Hash`es with `String` keys and `String` values ([#299](https://github.com/railsconfig/config/pull/299))
 
 ## 2.2.3
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -4,6 +4,7 @@ require 'config/configuration'
 require 'config/version'
 require 'config/sources/yaml_source'
 require 'config/sources/hash_source'
+require 'config/sources/env_source'
 require 'config/validation/schema'
 require 'deep_merge'
 
@@ -40,6 +41,8 @@ module Config
     [files].flatten.compact.uniq.each do |file|
       config.add_source!(file.to_s)
     end
+
+    config.add_source!(Sources::EnvSource.new(ENV)) if Config.use_env
 
     config.load!
     config

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -31,47 +31,6 @@ module Config
       @config_sources.unshift(source)
     end
 
-    def reload_env!
-      return self if ENV.nil? || ENV.empty?
-
-      hash = Hash.new
-
-      ENV.each do |variable, value|
-        separator = Config.env_separator
-        prefix = (Config.env_prefix || Config.const_name).to_s.split(separator)
-
-        keys = variable.to_s.split(separator)
-
-        next if keys.shift(prefix.size) != prefix
-
-        keys.map! { |key|
-          case Config.env_converter
-            when :downcase then
-              key.downcase.to_sym
-            when nil then
-              key.to_sym
-            else
-              raise "Invalid ENV variables name converter: #{Config.env_converter}"
-          end
-        }
-
-        leaf = keys[0...-1].inject(hash) { |h, key|
-          h[key] ||= {}
-        }
-
-        unless leaf.is_a?(Hash)
-          conflicting_key = (prefix + keys[0...-1]).join(separator)
-          raise "Environment variable #{variable} conflicts with variable #{conflicting_key}"
-        end
-
-        leaf[keys.last] = Config.env_parse_values ? __value(value) : value
-      end
-
-      merge!(hash)
-    end
-
-    alias :load_env! :reload_env!
-
     # look through all our sources and rebuild the configuration
     def reload!
       conf = {}
@@ -96,7 +55,6 @@ module Config
       # swap out the contents of the OStruct with a hash (need to recursively convert)
       marshal_load(__convert(conf).marshal_dump)
 
-      reload_env! if Config.use_env
       validate!
 
       self
@@ -222,18 +180,6 @@ module Config
         s[k] = v
       end
       s
-    end
-
-    # Try to convert string to a correct type
-    def __value(v)
-      case v
-      when 'false'
-        false
-      when 'true'
-        true
-      else
-        Integer(v) rescue Float(v) rescue v
-      end
     end
   end
 end

--- a/lib/config/sources/env_source.rb
+++ b/lib/config/sources/env_source.rb
@@ -1,0 +1,63 @@
+module Config
+  module Sources
+    # Allows settings to be loaded from a "flat" hash with string keys, like ENV.
+    class EnvSource
+      def initialize(env)
+        @env = env
+      end
+
+      def load
+        return {} if @env.nil? || @env.empty?
+
+        hash = Hash.new
+
+        @env.each do |variable, value|
+          separator = Config.env_separator
+          prefix = (Config.env_prefix || Config.const_name).to_s.split(separator)
+
+          keys = variable.to_s.split(separator)
+
+          next if keys.shift(prefix.size) != prefix
+
+          keys.map! { |key|
+            case Config.env_converter
+              when :downcase then
+                key.downcase
+              when nil then
+                key
+              else
+                raise "Invalid ENV variables name converter: #{Config.env_converter}"
+            end
+          }
+
+          leaf = keys[0...-1].inject(hash) { |h, key|
+            h[key] ||= {}
+          }
+
+          unless leaf.is_a?(Hash)
+            conflicting_key = (prefix + keys[0...-1]).join(separator)
+            raise "Environment variable #{variable} conflicts with variable #{conflicting_key}"
+          end
+
+          leaf[keys.last] = Config.env_parse_values ? __value(value) : value
+        end
+
+        hash
+      end
+
+      private
+
+      # Try to convert string to a correct type
+      def __value(v)
+        case v
+        when 'false'
+          false
+        when 'true'
+          true
+        else
+          Integer(v) rescue Float(v) rescue v
+        end
+      end
+    end
+  end
+end

--- a/spec/sources/env_source_spec.rb
+++ b/spec/sources/env_source_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+module Config::Sources
+  describe EnvSource do
+    context 'configuration options' do
+      before :each do
+        Config.reset
+        Config.env_prefix           = nil
+        Config.env_separator        = '.'
+        Config.env_converter        = :downcase
+        Config.env_parse_values     = true
+      end
+
+      context 'default configuration' do
+        it 'should use global prefix configuration by default' do
+          Config.env_prefix = 'MY_CONFIG'
+
+          source = EnvSource.new({ 'MY_CONFIG.ACTION_MAILER' => 'enabled' })
+          results = source.load
+          expect(results['action_mailer']).to eq('enabled')
+        end
+
+        it 'should use global separator configuration by default' do
+          Config.env_separator = '__'
+
+          source = EnvSource.new({ 'Settings__ACTION_MAILER__ENABLED' => 'yes' })
+          results = source.load
+          expect(results['action_mailer']['enabled']).to eq('yes')
+        end
+
+        it 'should use global converter configuration by default' do
+          Config.env_converter = nil
+
+          source = EnvSource.new({ 'Settings.ActionMailer.Enabled' => 'yes' })
+          results = source.load
+          expect(results['ActionMailer']['Enabled']).to eq('yes')
+        end
+
+        it 'should use global parse_values configuration by default' do
+          Config.env_parse_values = false
+
+          source = EnvSource.new({ 'Settings.ACTION_MAILER.ENABLED' => 'true' })
+          results = source.load
+          expect(results['action_mailer']['enabled']).to eq('true')
+        end
+      end
+
+      context 'configuration overrides' do
+        it 'should allow overriding prefix configuration' do
+          source = EnvSource.new({ 'MY_CONFIG.ACTION_MAILER' => 'enabled' },
+                                 prefix: 'MY_CONFIG')
+          results = source.load
+          expect(results['action_mailer']).to eq('enabled')
+        end
+
+        it 'should allow overriding separator configuration' do
+          source = EnvSource.new({ 'Settings__ACTION_MAILER__ENABLED' => 'yes' },
+                                 separator: '__')
+          results = source.load
+          expect(results['action_mailer']['enabled']).to eq('yes')
+        end
+
+        it 'should allow overriding converter configuration' do
+          source = EnvSource.new({ 'Settings.ActionMailer.Enabled' => 'yes' },
+                                 converter: nil)
+          results = source.load
+          expect(results['ActionMailer']['Enabled']).to eq('yes')
+        end
+
+        it 'should allow overriding parse_values configuration' do
+          source = EnvSource.new({ 'Settings.ACTION_MAILER.ENABLED' => 'true' },
+                                 parse_values: false)
+          results = source.load
+          expect(results['action_mailer']['enabled']).to eq('true')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In principle, loading settings from environment variables isn't much different from loading them from a `YAMLSource` or a `HashSource`. This change unifies the handling of environment variables into the existing "sources" abstraction.

My own personal motivation for this change is essentially the same as https://github.com/rubyconfig/config/issues/271. I want to load settings into `config` that I got from AWS Secrets Manager. Although AWS Secrets Manager's API _technically_ allows you to store arbitrary string values, the AWS Console UI and the AWS Secrets Manager API encourages you to store your application's secret configuration as as single Secret resource that is a flat, JSON-encoded key-value mapping. This maps very nicely to how one might use environment variables to configure an application.

### Editing secrets in the AWS console

<img width="620" alt="Screen Shot 2021-01-12 at 20 04 41" src="https://user-images.githubusercontent.com/954763/104405391-abcbd780-5511-11eb-930c-71c8a9f72e81.png">

### Actual plaintext

<img width="614" alt="Screen Shot 2021-01-12 at 20 10 37" src="https://user-images.githubusercontent.com/954763/104405631-4d532900-5512-11eb-90a3-86bd400344ec.png">


The problem is that while `config` offers the ability to parse nested settings from `ENV`, it doesn't allow you to do the same for settings you got from another source, like AWS Secrets Manager. As a result, users are forced into an awkward workaround: export all secrets from AWS Secrets Manager into `ENV`, then ask `config` to load the `ENV` again. My proposed `EnvSource` allows users to skip the loading-into-ENV step and just hand the flat `Hash` over to `config` directly.

 For example,
 
 ```ruby
# fetch secrets from AWS
client = Aws::SecretsManager::Client.new
response = client.get_secret_value(secret_id: "#{ENV['ENVIRONMENT']}/my_application")
secrets = JSON.parse(response.secret_string)

# load secrets into config
secret_source = Config::Sources::EnvSource.new(secrets)
Settings.add_source!(secret_source)
Settings.reload!
```