### PR TITLE
Add namespaces to YAML sources per #288

### DIFF
--- a/lib/config/sources/yaml_source.rb
+++ b/lib/config/sources/yaml_source.rb
@@ -6,15 +6,26 @@ module Config
     class YAMLSource
       attr_accessor :path
 
-      def initialize(path)
+      def initialize(path, namespace = nil)
         @path = path.to_s
+
+        # Make sure @namespace is an array if it exists at all
+        if namespace
+          @namespace = namespace
+          @namespace = [@namespace] unless @namespace.is_a?(Array)
+        end
       end
 
       # returns a config hash from the YML file
       def load
         result = YAML.load(ERB.new(IO.read(@path)).result) if @path and File.exist?(@path)
-
-        result || {}
+        return {} unless result
+        return result unless @namespace
+        
+        # Resolves namespacing multiple layers deep 
+        # i.e. ['layer1', 'layer2'] comes out to {'layer1' => {'layer2' => content}}
+        return  result = @namespace.reverse.inject(result) { |a, n| { n => a } }
+        
 
         rescue Psych::SyntaxError => e
           raise "YAML syntax error occurred while parsing #{@path}. " \

--- a/spec/sources/yaml_source_spec.rb
+++ b/spec/sources/yaml_source_spec.rb
@@ -25,6 +25,43 @@ module Config::Sources
       end
     end
 
+    context "basic yml file with single namespace" do
+      let(:source) do
+        YAMLSource.new "#{fixture_path}/development.yml", 'test_namespace'
+      end
+
+      it "should properly read the settings" do
+        results = source.load
+        expect(results['test_namespace']["size"]).to eq(2)
+      end
+
+      it "should properly read nested settings" do
+        results = source.load
+        pp results
+        expect(results['test_namespace']["section"]["size"]).to eq(3)
+        expect(results['test_namespace']["section"]["servers"]).to be_instance_of(Array)
+        expect(results['test_namespace']["section"]["servers"].size).to eq(2)
+      end
+    end
+
+    context "basic yml file with nested namespace" do
+      let(:source) do
+        YAMLSource.new "#{fixture_path}/development.yml", ['test_namespace', 'test_layer_2']
+      end
+
+      it "should properly read the settings" do
+        results = source.load
+        expect(results['test_namespace']['test_layer_2']["size"]).to eq(2)
+      end
+
+      it "should properly read nested settings" do
+        results = source.load
+        expect(results['test_namespace']['test_layer_2']["section"]["size"]).to eq(3)
+        expect(results['test_namespace']['test_layer_2']["section"]["servers"]).to be_instance_of(Array)
+        expect(results['test_namespace']['test_layer_2']["section"]["servers"].size).to eq(2)
+      end
+    end
+
     context "yml file with erb tags" do
       let(:source) do
         YAMLSource.new "#{fixture_path}/with_erb.yml"


### PR DESCRIPTION
This PR adds functionality for optional namespaces when creating a new `Config::Sources::YAMLSource` source or using `Settings.add_source!` per discussion in #288.

The functionality works like this:

Given a YAML file like this:
```yaml
foo:
  - bar
  - baz
  - chungus:
    - Bungus
```

The code works like this:
```ruby
# No namespace, same as current functionality
y = Config::Sources::YAMLSource.new("/tmp/example.yml")
y.load
=> {"foo"=>["bar", "baz", {"chungus"=>["Bungus"]}]}

# Single namespace, array or string both fine
y = Config::Sources::YAMLSource.new("/tmp/example.yml", 'new-level')
y.load
=> {"new-level"=>{"foo"=>["bar", "baz", {"chungus"=>["Bungus"]}]}}

# Nested namespace, given as array of keys
y = Config::Sources::YAMLSource.new("/tmp/example.yml", ['new-level', 'level-2'])
y.load
=> {"new-level"=>"level-2"=>{"foo"=>["bar", "baz", {"chungus"=>["Bungus"]}]}}}
```

Tests have been written and run to cover both cases based entirely on the existing `basic yml file` test case, called `basic yml file with single namespace` and `basic yml file with nested namespace` respectively.

I'm happy to make any changes necessary for code style (i.e. keyword method argument, ternary as opposed to multi-line, whatever) or functionality in keeping with existing standards for this codebase of which I may be ignorant.