### PR TITLE
Allow config option to disable ERB in YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ You may pass a hash to `prepend_source!` as well.
 
 ## Embedded Ruby (ERB)
 
-Embedded Ruby is allowed in the configuration files. Consider the two following config files.
+Embedded Ruby is allowed in the YAML configuration files. ERB will be evaluated at load time by default, and when the `evaluate_erb_in_yaml` configuration is set to `true`.
+
+Consider the two following config files.
 
 * ```#{Rails.root}/config/settings.yml```
 
@@ -266,6 +268,7 @@ After installing `Config` in Rails, you will find automatically generated file t
 ### General
 
 * `const_name` - name of the object holing you settings. Default: `'Settings'`
+* `evaluate_erb_in_yaml` - evaluate ERB in YAML config files. Set to false if the config file contains ERB that should not be evaluated at load time. Default: `true`
 
 ### Merge customization
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -24,7 +24,8 @@ module Config
     merge_nil_values: true,
     overwrite_arrays: true,
     merge_hash_arrays: false,
-    validation_contract: nil
+    validation_contract: nil,
+    evaluate_erb_in_yaml: true
   )
 
   def self.setup

--- a/lib/config/sources/yaml_source.rb
+++ b/lib/config/sources/yaml_source.rb
@@ -12,7 +12,11 @@ module Config
 
       # returns a config hash from the YML file
       def load
-        result = YAML.load(ERB.new(IO.read(@path)).result) if @path and File.exist?(@path)
+        if @path and File.exist?(@path)
+          file_contents = IO.read(@path)
+          file_contents = ERB.new(file_contents).result if Config.evaluate_erb_in_yaml
+          result = YAML.load(file_contents)
+        end
 
         result || {}
 

--- a/lib/config/sources/yaml_source.rb
+++ b/lib/config/sources/yaml_source.rb
@@ -5,16 +5,18 @@ module Config
   module Sources
     class YAMLSource
       attr_accessor :path
+      attr_reader :evaluate_erb
 
-      def initialize(path)
+      def initialize(path, evaluate_erb: Config.evaluate_erb_in_yaml)
         @path = path.to_s
+        @evaluate_erb = !!evaluate_erb
       end
 
       # returns a config hash from the YML file
       def load
         if @path and File.exist?(@path)
           file_contents = IO.read(@path)
-          file_contents = ERB.new(file_contents).result if Config.evaluate_erb_in_yaml
+          file_contents = ERB.new(file_contents).result if evaluate_erb
           result = YAML.load(file_contents)
         end
 

--- a/lib/generators/config/templates/config.rb
+++ b/lib/generators/config/templates/config.rb
@@ -52,4 +52,7 @@ Config.setup do |config|
   #   required(:email).filled(format?: EMAIL_REGEX)
   # end
 
+  # Evaluate ERB in YAML config files at load time.
+  #
+  # config.evaluate_erb_yaml = true
 end

--- a/spec/fixtures/with_malformed_erb.yml
+++ b/spec/fixtures/with_malformed_erb.yml
@@ -1,0 +1,1 @@
+malformed_erb: <%= = %>

--- a/spec/sources/yaml_source_spec.rb
+++ b/spec/sources/yaml_source_spec.rb
@@ -40,6 +40,50 @@ module Config::Sources
         expect(results["section"]["computed1"]).to eq(1)
         expect(results["section"]["computed2"]).to eq(2)
       end
+
+      context "with malformed erb tags" do
+        let(:source) do
+          YAMLSource.new "#{fixture_path}/with_malformed_erb.yml"
+        end
+
+        it "should properly evaluate the erb" do
+          expect {
+            source.load
+          }.to raise_error(SyntaxError)
+        end
+      end
+    end
+
+    context "yaml file with erb tags but erb disabled" do
+      let(:source) do
+        YAMLSource.new "#{fixture_path}/with_erb.yml"
+      end
+
+      around do |example|
+        original_evaluate_erb_in_yaml = Config.evaluate_erb_in_yaml
+        Config.evaluate_erb_in_yaml = false
+        example.run
+        Config.evaluate_erb_in_yaml = original_evaluate_erb_in_yaml
+      end
+
+      it "should load the file and leave the erb without being evaluated" do
+        results = source.load
+        expect(results["computed"]).to eq("<%= 1 + 2 + 3 %>")
+        expect(results["section"]["computed1"]).to eq("<%= \"1\" %>")
+      end
+
+      context "with malformed erb tags" do
+        let(:source) do
+          YAMLSource.new "#{fixture_path}/with_malformed_erb.yml"
+        end
+
+        it "should properly evaluate the erb" do
+          expect {
+            results = source.load
+            expect(results["malformed_erb"]).to eq("<%= = %>")
+          }.to_not raise_error
+        end
+      end
     end
 
     context "missing yml file" do

--- a/spec/sources/yaml_source_spec.rb
+++ b/spec/sources/yaml_source_spec.rb
@@ -27,7 +27,7 @@ module Config::Sources
 
     context "yml file with erb tags" do
       let(:source) do
-        YAMLSource.new "#{fixture_path}/with_erb.yml"
+        YAMLSource.new("#{fixture_path}/with_erb.yml")
       end
 
       it "should properly evaluate the erb" do
@@ -43,7 +43,7 @@ module Config::Sources
 
       context "with malformed erb tags" do
         let(:source) do
-          YAMLSource.new "#{fixture_path}/with_malformed_erb.yml"
+          YAMLSource.new("#{fixture_path}/with_malformed_erb.yml")
         end
 
         it "should properly evaluate the erb" do
@@ -56,14 +56,7 @@ module Config::Sources
 
     context "yaml file with erb tags but erb disabled" do
       let(:source) do
-        YAMLSource.new "#{fixture_path}/with_erb.yml"
-      end
-
-      around do |example|
-        original_evaluate_erb_in_yaml = Config.evaluate_erb_in_yaml
-        Config.evaluate_erb_in_yaml = false
-        example.run
-        Config.evaluate_erb_in_yaml = original_evaluate_erb_in_yaml
+        YAMLSource.new("#{fixture_path}/with_erb.yml", evaluate_erb: false)
       end
 
       it "should load the file and leave the erb without being evaluated" do
@@ -72,9 +65,28 @@ module Config::Sources
         expect(results["section"]["computed1"]).to eq("<%= \"1\" %>")
       end
 
+      context "with global config" do
+        let(:source) do
+          YAMLSource.new("#{fixture_path}/with_erb.yml")
+        end
+
+        around do |example|
+          original_evaluate_erb_in_yaml = Config.evaluate_erb_in_yaml
+          Config.evaluate_erb_in_yaml = false
+          example.run
+          Config.evaluate_erb_in_yaml = original_evaluate_erb_in_yaml
+        end
+
+        it "should load the file and leave the erb without being evaluated" do
+          results = source.load
+          expect(results["computed"]).to eq("<%= 1 + 2 + 3 %>")
+          expect(results["section"]["computed1"]).to eq("<%= \"1\" %>")
+        end
+      end
+
       context "with malformed erb tags" do
         let(:source) do
-          YAMLSource.new "#{fixture_path}/with_malformed_erb.yml"
+          YAMLSource.new("#{fixture_path}/with_malformed_erb.yml", evaluate_erb: false)
         end
 
         it "should properly evaluate the erb" do


### PR DESCRIPTION
## Problem

There is currently no way to disable ERB evaluation in YAML files at load time.

This is an issue if the config file has a string that contains ERB to be evaluated later, or something that looks like ERB. It simply raises an error (such as `SyntaxError` or `RuntimeError`) at application load time.


## Solution

Add the `Config.evaluate_erb_in_yaml` option, and use it to conditionally evaluate ERB or simply pass the string through.

This is fully backwards compatible as the value defaults to `true`.