### PR TITLE
Fix config.evaluate_erb_in_yaml typo

### DIFF
--- a/lib/generators/config/templates/config.rb
+++ b/lib/generators/config/templates/config.rb
@@ -54,5 +54,5 @@ Config.setup do |config|
 
   # Evaluate ERB in YAML config files at load time.
   #
-  # config.evaluate_erb_yaml = true
+  # config.evaluate_erb_in_yaml = true
 end


### PR DESCRIPTION
Just fixing commented out `evaluate_erb_in_yaml` typo in the configuration.