### PR TITLE
Allow symbol value via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ For instance, given the following environment:
 SETTINGS__SECTION__SERVER_SIZE=1
 SETTINGS__SECTION__SERVER=google.com
 SETTINGS__SECTION__SSL_ENABLED=false
-SETTINGS__SECTION__SERVER_ACCESS=:remote
+SETTINGS__SECTION__SERVER_TYPE=:remote
+SETTINGS__SECTION__SERVER_ACCESS=::ENABLED
 ```
 
 And the following configuration:
@@ -482,7 +483,8 @@ The following settings will be available:
 Settings.section.server_size # => 1
 Settings.section.server # => 'google.com'
 Settings.section.ssl_enabled # => false
-Settings.section.server_access # => :remote
+Settings.section.server_type # => :remote
+Settings.section.server_access # => '::ENABLED'
 ```
 
 ### Working with AWS Secrets Manager

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ You can customize how environment variables are processed:
 * `env_converter` (default: `:downcase`)  - how to process variables names:
   * `nil` - no change
   * `:downcase` - convert to lower case
-* `env_parse_values` (default: `true`) - try to parse values to a correct type (`Boolean`, `Integer`, `Float`, `String`)
+* `env_parse_values` (default: `true`) - try to parse values to a correct type (`Boolean`, `Integer`, `Float`, `String` & `Symbol`)
 
 For instance, given the following environment:
 
@@ -461,6 +461,7 @@ For instance, given the following environment:
 SETTINGS__SECTION__SERVER_SIZE=1
 SETTINGS__SECTION__SERVER=google.com
 SETTINGS__SECTION__SSL_ENABLED=false
+SETTINGS__SECTION__SERVER_ACCESS=:remote
 ```
 
 And the following configuration:
@@ -481,6 +482,7 @@ The following settings will be available:
 Settings.section.server_size # => 1
 Settings.section.server # => 'google.com'
 Settings.section.ssl_enabled # => false
+Settings.section.server_access # => :remote
 ```
 
 ### Working with AWS Secrets Manager

--- a/lib/config/sources/env_source.rb
+++ b/lib/config/sources/env_source.rb
@@ -62,10 +62,21 @@ module Config
         if %w(true false).include? v
           eval(v)
         elsif v.strip =~ /^:[^:]/
-          v.parameterize.underscore.to_sym
+          convert_str_to_symbol(v)
         else
           Integer(v) rescue Float(v) rescue v
         end
+      end
+
+      # Remove all special characters from a string before converting into a symbol
+      def convert_str_to_symbol(str)
+        str.
+          gsub(/[^a-z0-9\-_]+/i, "-").
+          gsub(/-{2,}/, "-").
+          gsub(/^-|-$/i, "").
+          tr("-", "_").
+          downcase.
+          to_sym
       end
     end
   end

--- a/lib/config/sources/env_source.rb
+++ b/lib/config/sources/env_source.rb
@@ -61,7 +61,7 @@ module Config
       def __value(v)
         if %w(true false).include? v
           eval(v)
-        elsif v.squish.start_with?(':')
+        elsif v.squish =~ /^:[^:]/
           v.parameterize.underscore.to_sym
         else
           Integer(v) rescue Float(v) rescue v

--- a/lib/config/sources/env_source.rb
+++ b/lib/config/sources/env_source.rb
@@ -61,7 +61,7 @@ module Config
       def __value(v)
         if %w(true false).include? v
           eval(v)
-        elsif v.squish =~ /^:[^:]/
+        elsif v.strip =~ /^:[^:]/
           v.parameterize.underscore.to_sym
         else
           Integer(v) rescue Float(v) rescue v

--- a/lib/config/sources/env_source.rb
+++ b/lib/config/sources/env_source.rb
@@ -59,11 +59,10 @@ module Config
 
       # Try to convert string to a correct type
       def __value(v)
-        case v
-        when 'false'
-          false
-        when 'true'
-          true
+        if %w(true false).include? v
+          eval(v)
+        elsif v.squish.start_with?(':')
+          v.parameterize.underscore.to_sym
         else
           Integer(v) rescue Float(v) rescue v
         end

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -77,6 +77,11 @@ describe Config::Options do
           expect(config.new_var.is_a? Float).to eq(true)
         end
 
+        it 'should recognize strings starting with : as symbols' do
+          ENV['Settings.new_var'] = ':hello'
+          expect(config.new_var).to eq(:hello)
+        end
+
         it 'should leave strings intact' do
           ENV['Settings.new_var'] = 'foobar'
 

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -78,8 +78,13 @@ describe Config::Options do
         end
 
         it 'should recognize strings starting with : as symbols' do
-          ENV['Settings.new_var'] = ':hello'
-          expect(config.new_var).to eq(:hello)
+          ENV['Settings.new_var'] = ':remote'
+          expect(config.new_var).to eq(:remote)
+        end
+
+        it 'should leave strings starting with :: intact' do
+          ENV['Settings.new_var'] = '::ENABLED'
+          expect(config.new_var).to eq('::ENABLED')
         end
 
         it 'should leave strings intact' do


### PR DESCRIPTION
This PR converts string starting with `:` to symbol. Allows symbol value via ENV.

`Config::Options` when overriding settings via ENV variables is enabled and parsing ENV variable values is enabled should recognize strings starting with `:` as symbols.

But strings starting with :: will be left intact.

Ex:
```
# Given the following environment:
SETTINGS__SECTION__SERVER_TYPE=:remote
SETTINGS__SECTION__SERVER_ACCESS=::ENABLED
```

```
# The following settings will be available:
Settings.section.server_type # => :remote
Settings.section.server_access # => '::ENABLED'
```

`String#strip` is used for removing whitespace characters from string inputs, such as: `'   :remote   '`, `'  :   '`, `'    :     remote   '`

`.gsub` is used to replace characters with the help of regex pattern match

`.tr` to covert to snakecase

`.downcase` to transform uppercase letters to lowercase

Ref: https://github.com/rubyconfig/config/issues/286