### PR TITLE
Support arbitrary sources in Config.load_files and Config.load_and_set_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-...
+### BREAKING CHANGES
+
+* Support `HashSource` and `EnvSource` instances in `Config.load_files` and `Config.load_and_set_settings`. ([#315](https://github.com/rubyconfig/config/pull/315)). There are a few subtle breaking changes:
+  * Previously, `Config.load_files` (called from `Config.load_and_set_settings`) would call `.to_s` on each of its arguments. Now, this responsibility is defered to YAMLSource. In effect, if your application passes String or Pathname objects to `Config.load_files`, no changes are necessary, but if you were somehow relying on the `.to_s` call for some other type of object, you'll now need to call `.to_s` on that object before passing it to `Config`.
+  * Before this change, `Config.load_files` would call `uniq` on its argument array. This call has been removed, so duplicate file paths are not removed before further processing. In some cases, this can cause differences in behavior since later config files override the values in earlier ones. In most cases, it's best to ensure that duplicate paths are not passed to `Config.load_files`.
 
 ## 3.1.1
 

--- a/README.md
+++ b/README.md
@@ -533,6 +533,33 @@ You are very warmly welcome to help. Please follow our [contribution guidelines]
 
 Any and all contributions offered in any form, past present or future are understood to be in complete agreement and acceptance with [MIT](LICENSE) license.
 
+### Running specs
+
+Setup
+
+```sh
+bundle install
+bundle exec appraisal install
+```
+
+List defined appraisals:
+
+```sh
+bundle exec appraisal list
+```
+
+Run specs for specific appraisal:
+
+```sh
+bundle exec appraisal rails-6.1 rspec
+```
+
+Run specs for all appraisals:
+
+```sh
+bundle exec appraisal rspec
+```
+
 ## Authors
 
 * [Piotr Kuczynski](http://github.com/pkuczynski)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -39,7 +39,7 @@ module Config
     config = Options.new
 
     # add settings sources
-    [sources].flatten.compact.uniq.each do |source|
+    [sources].flatten.compact.each do |source|
       source = source.to_s unless source.respond_to? :load
       config.add_source!(source)
     end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -40,7 +40,8 @@ module Config
 
     # add settings sources
     [sources].flatten.compact.uniq.each do |source|
-      config.add_source!(source.to_s)
+      source = source.to_s unless source.respond_to? :load
+      config.add_source!(source)
     end
 
     config.add_source!(Sources::EnvSource.new(ENV)) if Config.use_env

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -35,12 +35,12 @@ module Config
 
   # Create a populated Options instance from a settings file. If a second file is given, then the sections of that
   # file will overwrite existing sections of the first file.
-  def self.load_files(*files)
+  def self.load_files(*sources)
     config = Options.new
 
     # add settings sources
-    [files].flatten.compact.uniq.each do |file|
-      config.add_source!(file.to_s)
+    [sources].flatten.compact.uniq.each do |source|
+      config.add_source!(source.to_s)
     end
 
     config.add_source!(Sources::EnvSource.new(ENV)) if Config.use_env
@@ -50,10 +50,10 @@ module Config
   end
 
   # Loads and sets the settings constant!
-  def self.load_and_set_settings(*files)
+  def self.load_and_set_settings(*sources)
     name = Config.const_name
     Object.send(:remove_const, name) if Object.const_defined?(name)
-    Object.const_set(name, Config.load_files(files))
+    Object.const_set(name, Config.load_files(sources))
   end
 
   def self.setting_files(config_root, env)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -40,7 +40,6 @@ module Config
 
     # add settings sources
     [sources].flatten.compact.each do |source|
-      source = source.to_s unless source.respond_to? :load
       config.add_source!(source)
     end
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -16,7 +16,7 @@ module Config
 
     def add_source!(source)
       # handle yaml file paths
-      source = (Sources::YAMLSource.new(source)) if source.is_a?(String)
+      source = (Sources::YAMLSource.new(source)) if source.is_a?(String) || source.is_a?(Pathname)
       source = (Sources::HashSource.new(source)) if source.is_a?(Hash)
 
       @config_sources ||= []
@@ -24,7 +24,7 @@ module Config
     end
 
     def prepend_source!(source)
-      source = (Sources::YAMLSource.new(source)) if source.is_a?(String)
+      source = (Sources::YAMLSource.new(source)) if source.is_a?(String) || source.is_a?(Pathname)
       source = (Sources::HashSource.new(source)) if source.is_a?(Hash)
 
       @config_sources ||= []

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -66,6 +66,14 @@ describe Config do
     expect(config.server).to eq('google.com')
   end
 
+  it 'should load config from files and HashSource' do
+    file_source = "#{fixture_path}/settings.yml"
+    hash_source = Config::Sources::HashSource.new({ 'size' => 12 })
+    config = Config.load_files(file_source, hash_source)
+    expect(config.server).to eq('google.com')
+    expect(config.size).to eq(12)
+  end
+
   it "should load empty config for a missing file path" do
     config = Config.load_files("#{fixture_path}/some_file_that_doesnt_exist.yml")
     expect(config).to be_empty

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -45,6 +45,12 @@ describe Config do
     expect(config.another).to eq("something")
   end
 
+  it 'should load config files specified as Pathname objects' do
+    path = Pathname.new(fixture_path).join('settings.yml')
+    config = Config.load_files(path)
+    expect(config.server).to eq('google.com')
+  end
+
   it "should load empty config for a missing file path" do
     config = Config.load_files("#{fixture_path}/some_file_that_doesnt_exist.yml")
     expect(config).to be_empty

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -60,6 +60,12 @@ describe Config do
     expect(config.server).to eq('google.com')
   end
 
+  it 'should load config from HashSource' do
+    source = Config::Sources::HashSource.new({ 'server' => 'google.com' })
+    config = Config.load_files(source)
+    expect(config.server).to eq('google.com')
+  end
+
   it "should load empty config for a missing file path" do
     config = Config.load_files("#{fixture_path}/some_file_that_doesnt_exist.yml")
     expect(config).to be_empty

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,6 +51,15 @@ describe Config do
     expect(config.server).to eq('google.com')
   end
 
+  it 'should load config files specified as objects responding to :load' do
+    source = double 'source'
+    allow(source).to receive(:load) do
+      { 'server' => 'google.com' }
+    end
+    config = Config.load_files(source)
+    expect(config.server).to eq('google.com')
+  end
+
   it "should load empty config for a missing file path" do
     config = Config.load_files("#{fixture_path}/some_file_that_doesnt_exist.yml")
     expect(config).to be_empty


### PR DESCRIPTION
`Config.load_and_set_settings` is the most convenient interface for initializing the `Settings` object with a bunch of configuration sources. However, one problem is that it only allows paths to YAML files. This means that if the user wants to use an explicit `Config::Sources::HashSource` or a `Config::Sources::EnvSource` such as for AWS Secrets Manager, they have to call `add_source!` and `reload!` separately.

```ruby
Config.setup do |config|
  config.const_name = 'Settings'
end

Config.load_and_set_settings(
  Rails.root.join('config', 'settings', 'base.yml'),
  Rails.root.join('config', 'settings', 'default.yml')
)

secrets_source = Config::Sources::EnvSource.new(
  secrets_from_secrets_manager,
  parse_values: false
)
Settings.add_source!(secrets_source)
Settings.reload!
```

This is especially cumbersome if the user is using a validation contract and the settings aren't yet valid until adding the non-YAML sources. It's possible to work around this problem by setting the `validation_contact` _after_ adding all sources:

```ruby
Config.setup do |config|
  config.const_name = 'Settings'
end

Config.load_and_set_settings(
  Rails.root.join('config', 'settings', 'base.yml'),
  Rails.root.join('config', 'settings', 'default.yml')
)

secrets_source = Config::Sources::EnvSource.new(
  secrets_from_secrets_manager,
  parse_values: false
)
Settings.add_source!(secrets_source)

Config.validation_contract = ConfigContract.new
Settings.reload!
```

That's clunky. It'd be easier if the user could just specify the non-YAML sources up front.

```ruby
Config.setup do |config|
  config.const_name = 'Settings'
  config.validation_contract = ConfigContract.new
end

secrets_source = Config::Sources::EnvSource.new(
  secrets_from_secrets_manager,
  parse_values: false
)

Config.load_and_set_settings(
  Rails.root.join('config', 'settings', 'base.yml'),
  Rails.root.join('config', 'settings', 'default.yml'),
  secrets_source
)
```

This change makes this possible. There are some breaking changes in a few edge cases, but I expect that most applications will be able to upgrade without modification.