### PR TITLE
fix: remove deprecated method 'exists?' removed in ruby 3.0

### DIFF
--- a/lib/generators/config/install_generator.rb
+++ b/lib/generators/config/install_generator.rb
@@ -18,7 +18,7 @@ module Config
       end
 
       def modify_gitignore
-        create_file '.gitignore' unless File.exists? '.gitignore'
+        create_file '.gitignore' unless File.exist? '.gitignore'
 
         append_to_file '.gitignore' do
           "\n"                                +

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -4,7 +4,7 @@
 
 # Loads ENV vars from a yaml file
 def load_env(filename)
-  if filename and File.exists?(filename.to_s)
+  if filename and File.exist?(filename.to_s)
     result = YAML.load(ERB.new(IO.read(filename.to_s)).result)
   end
   result.each { |key, value| ENV[key.to_s] = value.to_s } unless result.nil?


### PR DESCRIPTION
It alllows to use the gem in a project based on Ruby > 2.7. The changed method doesn't exist anymore.