### PR TITLE
Only load `Railtie` integration if `Rails::Railtie` is defined

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -79,7 +79,7 @@ module Config
 end
 
 # Rails integration
-require('config/integrations/rails/railtie') if defined?(::Rails)
+require('config/integrations/rails/railtie') if defined?(::Rails::Railtie)
 
 # Sinatra integration
 require('config/integrations/sinatra') if defined?(::Sinatra)


### PR DESCRIPTION
As pointed by the [Rails documentation](https://api.rubyonrails.org/classes/Rails/Railtie.html#class-Rails::Railtie-label-Creating+a+Railtie), creating Railties should explicitly ensure that `Rails::Railtie` is defined.

There could be non-rails application use-cases where `Rails` is defined, yet `Rails::Railtie` is not loaded.

We looked into how to add a new test for this use-case but couldn't figure a simple way to load Rails without Railtie. Any idea how to do it? Or are we happy with the change without test?