### PR TITLE
fix indentation warning

### DIFF
--- a/lib/config/sources/yaml_source.rb
+++ b/lib/config/sources/yaml_source.rb
@@ -22,10 +22,10 @@ module Config
 
         result || {}
 
-        rescue Psych::SyntaxError => e
-          raise "YAML syntax error occurred while parsing #{@path}. " \
-                "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
-                "Error: #{e.message}"
+      rescue Psych::SyntaxError => e
+        raise "YAML syntax error occurred while parsing #{@path}. " \
+              "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
+              "Error: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
this minor change fixes a warning in ruby 3.1 about mismatched indentation.

```
safety@ditdash homelab % bundle exec ruby -v     
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin20]
safety@ditdash homelab % bundle info 
safety@ditdash homelab % sh
sh-3.2$ bundle exec ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin20]
sh-3.2$ bundle info config
  * config (4.0.0)
        Summary: Effortless multi-environment settings in Rails, Sinatra, Pandrino and others
        Homepage: https://github.com/rubyconfig/config
        Path: /Users/safety/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/config-4.0.0
sh-3.2$ bundle exec irb -w
irb(main):001:0> require 'config'
/Users/safety/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/config-4.0.0/lib/config/sources/yaml_source.rb:25: warning: mismatched indentations at 'rescue' with 'def' at 16
=> true
irb(main):002:0> 
```