### PR TITLE
allow to access Settings from Rails.application.settings

### DIFF
--- a/lib/config/integrations/rails/railtie.rb
+++ b/lib/config/integrations/rails/railtie.rb
@@ -1,6 +1,14 @@
 module Config
   module Integrations
     module Rails
+      module RailsSettings
+        attr_writer :settings
+
+        def settings
+          @settings = Object.const_get(Config.const_name)
+        end
+      end
+
       class Railtie < ::Rails::Railtie
         def preload
           # Manually load the custom initializer before everything else
@@ -19,6 +27,8 @@ module Config
         end
 
         config.before_configuration { preload }
+
+        ::Rails::Application.prepend RailsSettings
 
         # Development environment should reload settings on every request
         if ::Rails.env.development?


### PR DESCRIPTION
Implement #330 

As said in the Issue, this PR tries to make access of the `Settings` class from `Rails.application.settings`.