### PR TITLE
Address edge case with table config param

### DIFF
--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -112,7 +112,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max exit!].freeze
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max exit! table].freeze
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.
@@ -132,11 +132,11 @@ module Config
     end
 
     def key?(key)
-      table.key?(key)
+      @table.key?(key)
     end
 
     def has_key?(key)
-      table.has_key?(key)
+      @table.has_key?(key)
     end
 
     def method_missing(method_name, *args)

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -5,3 +5,4 @@ zip: cherry
 max: kumquat
 min: fig
 exit!: taro
+table: strawberry

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -18,6 +18,7 @@ describe Config::Options do
       expect(config.max).to eq('kumquat')
       expect(config.min).to eq('fig')
       expect(config.exit!).to eq('taro')
+      expect(config.table).to eq('strawberry')
     end
 
     it 'should allow to access them using [] operator' do
@@ -28,6 +29,7 @@ describe Config::Options do
       expect(config['max']).to eq('kumquat')
       expect(config['min']).to eq('fig')
       expect(config['exit!']).to eq('taro')
+      expect(config['table']).to eq('strawberry')
 
       expect(config[:select]).to eq('apple')
       expect(config[:collect]).to eq('banana')
@@ -36,6 +38,26 @@ describe Config::Options do
       expect(config[:max]).to eq('kumquat')
       expect(config[:min]).to eq('fig')
       expect(config[:exit!]).to eq('taro')
+      expect(config[:table]).to eq('strawberry')
+    end
+
+    context 'when empty' do
+      let(:config) do
+        Config.load_files("#{fixture_path}/empty1.yml")
+      end
+
+      it 'should allow to access them via object member notation' do
+        expect(config.select).to be_nil
+        expect(config.table).to be_nil
+      end
+
+      it 'should allow to access them using [] operator' do
+        expect(config['select']).to be_nil
+        expect(config['table']).to be_nil
+
+        expect(config[:select]).to be_nil
+        expect(config[:table]).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
There's a weird edge case when config parameter is named `table` but at the same time config is not provided. I expect it could be a common thing, like a database table that is not provided by default. Added the specs for this scenario that fail before the patch.

On Ruby 3.0+ it fails with this:

```
Failures:

  1) Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them via object member notation
     Failure/Error: expect(config.table).to be_nil
     
       expected: nil
            got: {}
     # ./spec/options_spec.rb:51:in `block (4 levels) in <main>'

  2) Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them using [] operator
     Failure/Error: expect(config['table']).to be_nil
     
       expected: nil
            got: {}
     # ./spec/options_spec.rb:56:in `block (4 levels) in <main>'

Finished in 0.15976 seconds (files took 0.40783 seconds to load)
137 examples, 2 failures

Failed examples:

rspec ./spec/options_spec.rb:49 # Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them via object member notation
rspec ./spec/options_spec.rb:54 # Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them using [] operator
```

On Ruby 2.7:

```
Failures:

  1) Config::Options when Settings file is using keywords reserved for OpenStruct should allow to access them using [] operator
     Failure/Error: expect(config['table']).to eq('strawberry')
     
       expected: "strawberry"
            got: {:collect=>"banana", :count=>"lemon", :exit!=>"taro", :max=>"kumquat", :min=>"fig", :select=>"apple", :table=>"strawberry", :zip=>"cherry"}
     
       (compared using ==)
     
       Diff:
       @@ -1,8 +1,15 @@
       -"strawberry"
       +:collect => "banana",
       +:count => "lemon",
       +:exit! => "taro",
       +:max => "kumquat",
       +:min => "fig",
       +:select => "apple",
       +:table => "strawberry",
       +:zip => "cherry",
       
     # ./spec/options_spec.rb:32:in `block (3 levels) in <main>'

  2) Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them using [] operator
     Failure/Error: expect(config['table']).to be_nil
     
       expected: nil
            got: {}
     # ./spec/options_spec.rb:56:in `block (4 levels) in <main>'

Finished in 0.13898 seconds (files took 0.362 seconds to load)
137 examples, 2 failures

Failed examples:

rspec ./spec/options_spec.rb:24 # Config::Options when Settings file is using keywords reserved for OpenStruct should allow to access them using [] operator
rspec ./spec/options_spec.rb:54 # Config::Options when Settings file is using keywords reserved for OpenStruct when empty should allow to access them using 
```