### PR TITLE
Bump actions/checkout and actions/cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           - truffleruby
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
@@ -35,7 +35,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.BUNDLE_PATH }}
           key: ruby-${{ matrix.ruby }}-gems-${{ hashFiles('config.gemspec', 'gemfiles/**') }}


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 and actions/cache v3  use an outdated version of node, so we will upgrade to v4, where Node 20 is the default. see [actions/checkout v4](https://github.com/actions/checkout/releases/tag/v4.0.0), [actions/cache v4](https://github.com/actions/cache/releases/tag/v4.0.0)