### PR TITLE
Prevent name collision with private methods from ancestors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Next
 
+### New features
+
 * Allow to use custom filename && directory name to store configs ([#341](https://github.com/rubyconfig/config/pull/341))
+
+### Bug fixes
+
 * Prevent name collision with private methods from ancestors ([#351](https://github.com/rubyconfig/config/pull/351))
 
 ## 5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+* Prevent name collision with private methods from ancestors ([#351](https://github.com/rubyconfig/config/pull/351))
+
 ## 5.1.0
 
 * Fix conflicts with Rails 7 active_support methods ([#347](https://github.com/rubyconfig/config/pull/347))

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -112,7 +112,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max table].freeze
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max exit! table].freeze
 
     # Some keywords that don't play nicely with Rails 7.*
     RAILS_RESERVED_NAMES = %w[maximum minimum].freeze

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -122,7 +122,7 @@ module Config
     def [](param)
       return super if SETTINGS_RESERVED_NAMES.include?(param)
       return super if RAILS_RESERVED_NAMES.include?(param)
-      send("#{param}")
+      public_send("#{param}")
     end
 
     def []=(param, value)

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -112,7 +112,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max exit! table].freeze
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max table].freeze
 
     # Some keywords that don't play nicely with Rails 7.*
     RAILS_RESERVED_NAMES = %w[maximum minimum].freeze

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -7,6 +7,8 @@ max: kumquat
 min: fig
 exit!: taro
 table: strawberry
+lambda: proc
+proc: lambda 
 
 # Rails 7.* reserved keywords
 minimum: 10

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -70,6 +70,7 @@ describe Config::Options do
       it 'should allow to access them via object member notation' do
         expect(config.select).to be_nil
         expect(config.table).to be_nil
+        expect(config.exit!).to be_nil        
       end
 
       it 'should allow to access them using [] operator' do
@@ -77,9 +78,11 @@ describe Config::Options do
         expect(config['table']).to be_nil
         expect(config['lambda']).to be_nil
         expect(config['proc']).to be_nil
+        expect(config['exit!']).to be_nil
 
         expect(config[:select]).to be_nil
         expect(config[:table]).to be_nil
+        expect(config[:exit!]).to be_nil
       end
     end
   end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -19,6 +19,8 @@ describe Config::Options do
       expect(config.min).to eq('fig')
       expect(config.exit!).to eq('taro')
       expect(config.table).to eq('strawberry')
+      expect(config.lambda).to eq('proc')
+      expect(config.proc).to eq('lambda')
     end
 
     it 'should allow to access them using [] operator' do
@@ -30,6 +32,8 @@ describe Config::Options do
       expect(config['min']).to eq('fig')
       expect(config['exit!']).to eq('taro')
       expect(config['table']).to eq('strawberry')
+      expect(config['lambda']).to eq('proc')
+      expect(config['proc']).to eq('lambda')
 
       expect(config[:select]).to eq('apple')
       expect(config[:collect]).to eq('banana')
@@ -39,6 +43,8 @@ describe Config::Options do
       expect(config[:min]).to eq('fig')
       expect(config[:exit!]).to eq('taro')
       expect(config[:table]).to eq('strawberry')
+      expect(config[:lambda]).to eq('proc')
+      expect(config[:proc]).to eq('lambda')
     end
 
     context 'when Settings file is using keywords reserved by Rails 7' do
@@ -69,6 +75,8 @@ describe Config::Options do
       it 'should allow to access them using [] operator' do
         expect(config['select']).to be_nil
         expect(config['table']).to be_nil
+        expect(config['lambda']).to be_nil
+        expect(config['proc']).to be_nil
 
         expect(config[:select]).to be_nil
         expect(config[:table]).to be_nil


### PR DESCRIPTION
I caught error when accessing an option named `lambda`
```
>> config['lambda']
# ArgumentError: tried to create Proc object without a block
from bundle/ruby/2.6.0/gems/config-2.2.3/lib/config/options.rb:161:in `lambda'
```
The methods used to access options are always public, so there is no need to use send. Using send can cause problems because it can call private and protected methods of the base classes. I replaced send with public_send. This will avoid the problems caused by send calling private and protected methods.