### PR TITLE
Address fixture path deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,13 @@ when 'sinatra'
   end
 end
 
+module FixturePathHelper
+  def fixture_path
+    # Call fixture_paths.first in Rails >= 7.1 to avoid deprecation warnings
+    respond_to?(:fixture_paths) ? fixture_paths.first : super
+  end
+end
+
 ##
 # Common Rspec configure
 #
@@ -84,6 +91,8 @@ RSpec.configure do |config|
       end
     end
   end
+
+  config.include FixturePathHelper
 end
 
 ##


### PR DESCRIPTION
Fixes [deprecation warning](https://guides.rubyonrails.org/7_1_release_notes.html#active-record-deprecations) in Rails 7.1

```
DEPRECATION WARNING: TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.
If multiple fixture paths have been configured with #fixture_paths, then #fixture_path will just return
the first path.
```

Since the test suite supports older Rails versions and `fixtures_paths` was introduced in Rails 7.1, we continue to call `fixture_path` unless `fixtures_path` is available.