### PR TITLE
config.gemspec: use `funding_url` rather than `post_install_message`

### DIFF
--- a/config.gemspec
+++ b/config.gemspec
@@ -14,13 +14,10 @@ Gem::Specification.new do |s|
   s.license          = 'MIT'
   s.extra_rdoc_files = %w[README.md CHANGELOG.md CONTRIBUTING.md LICENSE.md]
   s.rdoc_options     = ['--charset=UTF-8']
-  s.post_install_message = "\n\e[33mThanks for installing Config\e[0m
-Please consider donating to our open collective to help us maintain this project.
-\n
-Donate: \e[34mhttps://opencollective.com/rubyconfig/donate\e[0m\n"
 
   s.metadata = {
     'changelog_uri' => "https://github.com/rubyconfig/config/blob/master/CHANGELOG.md",
+    'funding_url' => 'https://opencollective.com/rubyconfig/donate',
     'source_code_uri' => 'https://github.com/rubyconfig/config',
     'bug_tracker_uri' => 'https://github.com/rubyconfig/config/issues'
   }


### PR DESCRIPTION
Hello 👋🏼

This is a friendly PR to shift the request for funding from the general-purpose `post_install_message` to the specific `funding_uri` system [supported by bundler 2.2+](https://bundler.io/blog/2020/12/09/bundler-v2-2.html).

I think this is more in line with etiquette of the community. To quantify that with some anecdata, the main Rails app I work on has ~340 gem dependencies, and I took the time to do a clean install and observe the `post_install_message`s. There's 8 in total:

- 4 API change/deprecation notice
- 1 notice of a non-declared soft dependency on another gem
- 1 notice regarding EOL/maintenance schedule
- 1 nonsense from httparty
- 1 relating to sponsorship/funding: `config` 


Related:

> If you develop a gem that needs funding, make sure you fill in the `funding_uri` metadata in your gemspec, like this …
> … `bundle fund` will start reporting all of your dependencies that need funding.

— https://bundler.io/blog/2020/12/09/bundler-v2-2.html

> `  "funding_uri"       => "https://example.com/donate"`

— https://guides.rubygems.org/specification-reference/

Thanks! 🙏🏼