### PR TITLE
Fix a typo in gemspec

### DIFF
--- a/config.gemspec
+++ b/config.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'changelog_uri' => "https://github.com/rubyconfig/config/blob/master/CHANGELOG.md",
-    'funding_url' => 'https://opencollective.com/rubyconfig/donate',
+    'funding_uri' => 'https://opencollective.com/rubyconfig/donate',
     'source_code_uri' => 'https://github.com/rubyconfig/config',
     'bug_tracker_uri' => 'https://github.com/rubyconfig/config/issues'
   }


### PR DESCRIPTION
According to the document, `funding_uri` is a correct key, not `funding_url`.

* https://bundler.io/blog/2020/12/09/bundler-v2-2.html#find-out-about-gems-you-depend-on-that-need-funding
* https://guides.rubygems.org/specification-reference/#metadata