### PR TITLE
Fix warning: ostruct was loaded from the standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix warning: ostruct was loaded from the standard library ([#363](https://github.com/rubyconfig/config/pull/363))
+
 ## 5.5.1
 
 ### Documentation

--- a/config.gemspec
+++ b/config.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'
+  s.add_dependency 'ostruct'
 
   s.add_development_dependency 'dry-validation', *Config::DryValidationRequirements::VERSIONS
   s.add_development_dependency 'rake', '~> 12.0', '>= 12.0.0'


### PR DESCRIPTION
It fixes a warning of loading ostruct gem from standard library with Ruby 3.3.5 and 3.4+.

The warning message is following:
```
/path/config/lib/config.rb:1: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

- ruby: 3.3.5
- config gem: 5.5.1

### Related Links
- https://github.com/ruby/ruby/pull/10428
- https://bugs.ruby-lang.org/issues/20309

### Additional information
This warning category is `performance`.
It may be better to reduce the dependency of ostruct.

> OpenStruct use is discouraged for performance reasons

https://github.com/ruby/ostruct/pull/56

Closes #365
