### PR TITLE
Add ostruct as dependency to gemspec

### DIFF
--- a/config.gemspec
+++ b/config.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'
+  s.add_dependency 'ostruct'
 
   s.add_development_dependency 'dry-validation', *Config::DryValidationRequirements::VERSIONS
   s.add_development_dependency 'rake', '~> 12.0', '>= 12.0.0'


### PR DESCRIPTION
This should silence warnings like:

```
.../ruby/3.3.0/gems/config-5.5.1/lib/config/options.rb:1: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.00:03
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

See https://github.com/ruby/ruby/pull/10428 for more information.