### PR TITLE
fix(security): replace `IO.read` with `File.read`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Next
+
+* fix(security): replace IO.read with File.read [#378](https://github.com/rubyconfig/config/pull/378)
+
 ## 5.6.0
 
-* Added `extra_sources` in initializer  ([#366](https://github.com/rubyconfig/config/pull/366))
+* Added `extra_sources` in initializer ([#366](https://github.com/rubyconfig/config/pull/366))
 
 ## 5.5.2
 

--- a/lib/config/sources/yaml_source.rb
+++ b/lib/config/sources/yaml_source.rb
@@ -15,7 +15,7 @@ module Config
       # returns a config hash from the YML file
       def load
         if @path and File.exist?(@path)
-          file_contents = IO.read(@path)
+          file_contents = File.read(@path)
           file_contents = ERB.new(file_contents).result if evaluate_erb
           result = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(file_contents) : YAML.load(file_contents)
         end

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -5,7 +5,7 @@
 # Loads ENV vars from a yaml file
 def load_env(filename)
   if filename and File.exist?(filename.to_s)
-    result = YAML.load(ERB.new(IO.read(filename.to_s)).result)
+    result = YAML.load(ERB.new(File.read(filename.to_s)).result)
   end
   result.each { |key, value| ENV[key.to_s] = value.to_s } unless result.nil?
 end


### PR DESCRIPTION
Potential fix for [https://github.com/rubyconfig/config/security/code-scanning/4](https://github.com/rubyconfig/config/security/code-scanning/4)

To fix the problem, replace `IO.read` with `File.read`. The `File.read` method does not allow shell execution through inputs starting with `|`. This ensures the code remains secure against malicious inputs. The functionality of reading the file content is preserved with no change in behavior.

The changes will be made in the file `spec/support/rails_helper.rb`, specifically on line 8. The replacement ensures that the file content is read securely using `File.read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
