### PR TITLE
ci: limit workflow permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: tests
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/rubyconfig/config/security/code-scanning/2](https://github.com/rubyconfig/config/security/code-scanning/2)

To fix the problem, add a `permissions` block to the root of the workflow and specify the minimal privileges required. Since this workflow primarily reads repository content and interacts with pull requests and code coverage, the permissions can be limited to `contents: read` and `pull-requests: write`. The `permissions` block will be applied globally to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
